### PR TITLE
PWEB-5275 - fix ScribbleQt example to take the port number on the command line

### DIFF
--- a/ScribbleAppQt/main.cpp
+++ b/ScribbleAppQt/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 	  qDebug() << "serverAddress is not empty " << serverAddress << " , " << port;
 	  CSI::String sAddress = "127.0.0.1"; //serverAddress.toStdString().c_str();
 	  int sPort = port.toInt();
-	  server->Start(stateManager.get(),sAddress,8085);
+	  server->Start(stateManager.get(),sAddress,sPort);
 	}
 
         server->ShutdownRequested() += PureWebCommon::OnPureWebShutdown;

--- a/ScribbleAppQt/service.json
+++ b/ScribbleAppQt/service.json
@@ -1,6 +1,6 @@
 [
  {
-    "Name": "scribble",
+    "Name": "ScribbleQt",
     "Description": "Scribble Qt App C++",
     "Executable": "./scribble",
     "Directory": "../apps/ScribbleAppQt",


### PR DESCRIPTION
Also change service.json to use the new naming scheme
